### PR TITLE
Fix skid steer turning for test robot

### DIFF
--- a/rdt_legacy_robot/description/component_macros.xacro
+++ b/rdt_legacy_robot/description/component_macros.xacro
@@ -35,7 +35,7 @@
                     <box size="${length} ${width} ${height}"/>
                 </geometry>
                 <material name="white"/>
-            </visual>
+            </visual>                        
             <collision>
                 <origin xyz="${length/2} 0 ${height/2}"/>
                 <geometry>

--- a/rdt_legacy_robot/launch/launch_sim.launch.py
+++ b/rdt_legacy_robot/launch/launch_sim.launch.py
@@ -4,6 +4,8 @@ from ament_index_python import get_package_share_directory
 
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 from launch_ros.actions import Node
@@ -12,7 +14,7 @@ def generate_launch_description():
     pkg_name = 'rdt_legacy_robot'
 
     gazebo_world_file = os.path.join(
-        get_package_share_directory(pkg_name), 'worlds', 'demo_world.world'
+        get_package_share_directory(pkg_name), 'nyu_world.world'
     )
 
     rsp = IncludeLaunchDescription(
@@ -27,7 +29,7 @@ def generate_launch_description():
         )]),
         launch_arguments={'world': gazebo_world_file}.items()
     )
-
+  
     spawn_entity = Node(
         package='gazebo_ros',
         executable='spawn_entity.py',
@@ -39,4 +41,5 @@ def generate_launch_description():
         rsp,
         gazebo,
         spawn_entity
-    ])
+        ],
+    )

--- a/rdt_legacy_robot/setup.cfg
+++ b/rdt_legacy_robot/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/rdt_legacy_robot
+script_dir=$base/lib/rdt_legacy_robot
 [install]
-install-scripts=$base/lib/rdt_legacy_robot
+install_scripts=$base/lib/rdt_legacy_robot

--- a/rdt_legacy_robot/setup.py
+++ b/rdt_legacy_robot/setup.py
@@ -14,6 +14,7 @@ setup(
         ('share/' + package_name, ['package.xml']),
         (os.path.join('share', package_name), glob('launch/*.launch.py')),
         (os.path.join('share', package_name), glob('description/*')),
+        (os.path.join('share', package_name), glob('worlds/*')),
     ],
     install_requires=['setuptools'],
     zip_safe=True,

--- a/rdt_legacy_robot/worlds/nyu_world.world
+++ b/rdt_legacy_robot/worlds/nyu_world.world
@@ -1,5 +1,5 @@
 <sdf version='1.7'>
-  <world name='default'>
+  <world name='arena'>
     <light name='sun' type='directional'>
       <cast_shadows>1</cast_shadows>
       <pose>0 0 10 0 -0 0</pose>
@@ -18,7 +18,7 @@
         <falloff>0</falloff>
       </spot>
     </light>
-    <model name='ground_plane'>
+    <model name='arena_plane'>
       <static>1</static>
       <link name='link'>
         <collision name='collision'>
@@ -29,20 +29,29 @@
             </plane>
           </geometry>
           <surface>
-            <contact>
-              <collide_bitmask>65535</collide_bitmask>
-              <ode/>
-            </contact>
             <friction>
               <ode>
-                <mu>100</mu> 
-                <mu2>50</mu2>
+                <mu>50.000000</mu>
+                <mu2>50.000000</mu2>
+                <fdir1>0.000000 1.000000 0.000000</fdir1>
+                <slip1>0.0100000</slip1>
+                <slip2>0.0100000</slip2>
               </ode>
-              <torsional>
-                <ode/>
-              </torsional>
             </friction>
-            <bounce/>
+            <bounce>
+              <restitution_coefficient>0.000000</restitution_coefficient>
+              <threshold>100000.000000</threshold>
+            </bounce>
+            <contact>
+              <ode>
+                <soft_cfm>0.000000</soft_cfm>
+                <soft_erp>0.200000</soft_erp>
+                <kp>1000000000.000000</kp>
+                <kd>1.000000</kd>
+                <max_vel>100.000000</max_vel>
+                <min_depth>0.001000</min_depth>
+              </ode>
+            </contact>
           </surface>
           <max_contacts>10</max_contacts>
         </collision>
@@ -92,7 +101,7 @@
       <real_time>72 222228069</real_time>
       <wall_time>1706490810 80892577</wall_time>
       <iterations>64404</iterations>
-      <model name='ground_plane'>
+      <model name='arena_ground'>
         <pose>0 0 0 0 -0 0</pose>
         <scale>1 1 1</scale>
         <link name='link'>


### PR DESCRIPTION
Renamed the world file to nyu_world so that we can see if it loaded.
World renamed to arena so that it's clear which object was loaded from this new file.

Modified setup.py to copy over your version of the worlds file.

Removed 'worlds' keyword from the path because the setup.py copies the world files over to the root of the install folder.

Played with friction parameters in the world file.  The whole set is copied from a skid steer recommendation.  slip1/slip2 seem to be the paramters that helped the most, but I left everything else in there in case I'm missing something.

There is also a change to setup.cfg to fix a warning that starts occurring in ros humble.